### PR TITLE
Fix backup script to write error to log

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -10,7 +10,6 @@
 #
 # version: 1.1.0
 #
-set -e
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions
@@ -37,7 +36,12 @@ purgeOld()
     if [[ ${keep} -gt 0 ]]; then
         _log "Purging old files..."
         find "${backupDir}" -maxdepth ${OMV_BACKUP_MAX_DEPTH} -type f -mtime +${keep} -name "${OMV_BACKUP_FILE_PREFIX}*" -delete
-        _log "Purging done."
+        if [ $? -eq 0 ]; then
+            _log "Purging done."
+        else
+            _log "Purge failed!"
+            exit 1
+        fi
     else
         _log "Purging disabled."
     fi
@@ -107,10 +111,28 @@ fi
 # save helpful information
 _log "Save fdisk output for ${root}"
 fdisk -l ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fdisk"
+if [ $? -eq 0 ]; then
+    _log "Saved fdisk output for ${root}"
+else
+    _log "Save of fdisk output for ${root} failed!"
+    exit 1
+fi
 _log "Save blkid output"
 blkid > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.blkid"
+if [ $? -eq 0 ]; then
+    _log "Saved blkid output"
+else
+    _log "Save of blkid output failed!"
+    exit 1
+fi
 _log "Save package list"
 dpkg -l | grep openmediavault > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.packages"
+if [ $? -eq 0 ]; then
+    _log "Saved package list"
+else
+    _log "Save of package list failed!"
+    exit 1
+fi
 
 # calculate partition table size to accommodate GPT and MBR.
 part_type=$(blkid -p ${root} | cut -d \" -f4)
@@ -126,8 +148,14 @@ if [ "${part_type}" = "gpt" ]; then
     esppart="${root}${partletter}${esp}"
     _log "ESP partition :: ${esppart}"
     if [ -e "${esppart}" ]; then
-      _log "Backup ESP partition"
-      dd if=${esppart} bs=1M conv=sync,noerror status=progress | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.espdd.gz"
+    	_log "Backup ESP partition"
+    	dd if=${esppart} bs=1M conv=sync,noerror status=progress | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.espdd.gz"
+        if [ $? -eq 0 ]; then
+            _log "Backuped ESP partition"
+        else
+            _log "Backup of ESP partition failed!"
+            exit 1
+        fi
     else
       _log "ESP partition '${esppart}' not found."
     fi
@@ -137,10 +165,22 @@ fi
 
 
 # save partition table and mbr
-_log "Save mbr"
-dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
-_log "Save mbr and partition table"
-dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
+	_log "Save mbr"
+	dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
+    if [ $? -eq 0 ]; then
+        _log "Saved MBR"
+    else
+        _log "Save of MBR failed!"
+        exit 1
+    fi
+	_log "Save mbr and partition table"
+	dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
+    if [ $? -eq 0 ]; then
+        _log "Saved MBR and partition table"
+    else
+        _log "Save of MBR and partition table failed!"
+        exit 1
+    fi
 
 # check for /boot partition
 bootpart=$(awk '$2 == "/boot" { print $1 }' /proc/mounts)
@@ -156,6 +196,12 @@ if [ -f "/usr/lib/u-boot/platform_install.sh" ]; then
     if [ -d "${DIR}" ]; then
         _log "Backup u-boot"
         tar cjf "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}_u-boot.tar.bz" ${DIR}/*
+        if [ $? -eq 0 ]; then
+            _log "Backuped u-boot"
+        else
+            _log "Backup of u-boot failed!"
+            exit 1
+        fi
     fi
 fi
 
@@ -169,6 +215,7 @@ case ${method} in
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
             _log "dd backup failed!"
+			exit 1
         else
             _log "dd backup complete."
         fi
@@ -176,7 +223,12 @@ case ${method} in
         if [ -n "${bootpart}" ]; then
             _log "Starting dd backup of boot partition..."
             dd if=${bootpart} bs=1M conv=sync,noerror status=progress | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}_boot.dd.gz"
-            _log "dd backup of boot partition complete."
+            if [ $? -eq 0 ]; then
+                _log "dd backup of boot partition complete."
+            else
+                _log "dd backup of boot partition failed!"
+                exit 1
+            fi
         fi
         sync
         touch "${backupDir}/${OMV_BACKUP_FILE_PREFIX}"-${date}*.dd.gz
@@ -191,6 +243,7 @@ case ${method} in
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
             _log "dd full disk backup failed!"
+			exit 1
         else
             _log "dd full disk backup complete."
         fi
@@ -212,6 +265,7 @@ case ${method} in
         fsarchiver savefs ${password}-o "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fsa" ${devicefile} ${bootpart} -v -A ${extra}
         if [ $? -ne 0 ]; then
             _log "FSArchiver backup failed!"
+			exit 1
         else
             _log "FSArchiver backup complete."
         fi
@@ -244,6 +298,7 @@ case ${method} in
           -e "/media" -e "/lost+found" -e "/export" -e "/home/ftp" -e "/srv" ${extra}
         if [ $? -ne 0 ]; then
             _log "borgbackup create failed!"
+			exit 1
         else
             _log "borgbackup create complete."
         fi
@@ -252,7 +307,12 @@ case ${method} in
           purgeOld
           _log "Starting borgbackup prune..."
           borg prune "${backupDir}/borgbackup" --keep-daily "${keep}"
-          _log "borgbackup prune complete."
+          if [ $? -ne 0 ]; then
+		  	_log "borgbackup prune failed!"
+			exit 1	
+          else
+            _log "borgbackup prune complete."
+		  fi
         fi
         ;;
 
@@ -275,6 +335,7 @@ case ${method} in
             --exclude=/srv ${extra}
         if [ $? -ne 0 ]; then
             _log "rsync backup failed!"
+			exit 1
         else
             _log "rsync backup complete."
         fi


### PR DESCRIPTION
Instead of having set -e and asking errors to be written to log by checking if the last command have failed (which couldn't work), manuals fails checks have been added at major steps.

These fails checks print the error to the log, and only after exit the script with an error (1).